### PR TITLE
[BUG] Fixing import backup data

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -1109,7 +1109,7 @@ function importData() {
                 input.click();
             }
         }
-    });
+    }, document.body);
 }
 
 function exportData() {


### PR DESCRIPTION
Import data isn't working.
After debugging I found it because import dialog isn't having a container to render.
Technically, second param (container) when call satus.render() is empty for importData()